### PR TITLE
Fix article links positioning

### DIFF
--- a/external-resources/index.html
+++ b/external-resources/index.html
@@ -43,6 +43,10 @@ description: Extensions, integrations, blog posts and videos about WireMock from
     
     <p>Maciej Walkowiak has built a library providing zero-config, fully declarative Spring Boot integration with WireMock in JUnit 5 tests:</p>
     <a href="https://github.com/maciejwalkowiak/wiremock-spring-boot">https://github.com/maciejwalkowiak/wiremock-spring-boot</a>
+
+    <p>@GenerateWireMockStub for Spring REST controllers, built by Lukasz Gryzbon, makes the creation of WireMock stubs for tests safe and effortless:</p>
+    <a href="https://github.com/lsd-consulting/spring-wiremock-stub-generator">https://github.com/lsd-consulting/spring-wiremock-stub-generator</a>
+
     <h4>
         Extensions
     </h4>
@@ -183,6 +187,18 @@ description: Extensions, integrations, blog posts and videos about WireMock from
 <a href="http://www.ontestautomation.com/open-sourcing-my-workshop-on-wiremock/">
     http://www.ontestautomation.com/open-sourcing-my-workshop-on-wiremock/
 </a>
+
+<p>
+    @GenerateWireMockStub for Spring REST controllers, built by Lukasz Gryzbon, makes the creation of WireMock stubs for tests safe and effortless:
+</p>
+
+<a href="https://dzone.com/articles/wiremock-the-ridiculously-easy-way">
+    https://dzone.com/articles/wiremock-the-ridiculously-easy-way
+</a>
+
+<p>
+    WireMock workshop:
+</p>
 
 <a href="https://github.com/basdijkstra/wiremock-workshop">
     https://github.com/basdijkstra/wiremock-workshop


### PR DESCRIPTION
It appears the recent change to add a link to the https://dzone.com/articles/wiremock-the-ridiculously-easy-way article, messed up the positioning of the WireMock Workshop link:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/5703054/235632669-a6af0e63-e570-4c94-893c-a3db9976c7ef.png">

Hopefully, this PR fixes it.